### PR TITLE
Updates to fix reporting plug-ins

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,20 @@
 # apereo-parent [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.jasig.parent/jasig-parent/badge.svg?style=flat)]
 Apereo parent pom for Apereo Maven projects.  
+
+# Revisions
+
+## Version 41
+Updates the license headers to Apereo and includes the reporting plug-ins again.
+
+## Version 40
+Starting with version 40, the license plug-in changed from
+```
+<groupId>com.mycila.maven-license-plugin</groupId>
+<artifactId>maven-license-plugin</artifactId>
+```
+to
+```
+<groupId>com.mycila</groupId>
+<artifactId>license-maven-plugin</artifactId>
+```
+You will need to update your pom for this.

--- a/licenses/NOTICE.template
+++ b/licenses/NOTICE.template
@@ -1,17 +1,17 @@
-Copyright 2010, JA-SIG, Inc.
-This project includes software developed by Jasig.
-http://www.jasig.org/
+Licensed to Apereo under one or more contributor license
+agreements. See the NOTICE file distributed with this work
+for additional information regarding copyright ownership.
+Apereo licenses this file to you under the Apache License,
+Version 2.0 (the "License"); you may not use this file
+except in compliance with the License.  You may obtain a
+copy of the License at the following location:
 
-Licensed under the Apache License, Version 2.0 (the
-"License"); you may not use this file except in compliance
-with the License. You may obtain a copy of the License at:
-
-http://www.apache.org/licenses/LICENSE-2.0
+  http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing,
-software distributed under the License is distributed on
-an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-KIND, either express or implied. See the License for the
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 

--- a/licenses/license-mappings.xml
+++ b/licenses/license-mappings.xml
@@ -1202,6 +1202,11 @@
         <license>Apache License, Version 2.0</license>
     </artifact>
     <artifact>
+        <groupId>opensymphony</groupId>
+        <artifactId>ognl</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
         <groupId>org.jasig.cas.client</groupId>
         <artifactId>cas-client-core</artifactId>
         <license>Apache License, Version 2.0</license>

--- a/licenses/short-license-header.txt
+++ b/licenses/short-license-header.txt
@@ -1,16 +1,16 @@
-Licensed to Jasig under one or more contributor license
+Licensed to Apereo under one or more contributor license
 agreements. See the NOTICE file distributed with this work
 for additional information regarding copyright ownership.
-Jasig licenses this file to you under the Apache License,
+Apereo licenses this file to you under the Apache License,
 Version 2.0 (the "License"); you may not use this file
-except in compliance with the License. You may obtain a
-copy of the License at:
+except in compliance with the License.  You may obtain a
+copy of the License at the following location:
 
-http://www.apache.org/licenses/LICENSE-2.0
+  http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing,
-software distributed under the License is distributed on
-an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-KIND, either express or implied. See the License for the
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.

--- a/pom.xml
+++ b/pom.xml
@@ -62,16 +62,20 @@
 		<maven.legal.plugin.ver>1.0.2</maven.legal.plugin.ver>
 		<maven.notice.plugin.ver>1.0.6.1</maven.notice.plugin.ver>
 		<maven.site.plugin.ver>3.4</maven.site.plugin.ver>
-		<maven.jxr.plugin.ver>2.5</maven.jxr.plugin.ver>
-		<maven.project.info.reports.plugin.ver>2.8</maven.project.info.reports.plugin.ver>
-		<maven.surefire.report.plugin.ver>2.18.1</maven.surefire.report.plugin.ver>
-		<cobertura.maven.plugin.ver>2.7</cobertura.maven.plugin.ver>
-		<maven.pmd.plugin.ver>3.4</maven.pmd.plugin.ver>
-		<maven.changelog.plugin.ver>2.3</maven.changelog.plugin.ver>
-		<findbugs.maven.plugin.ver>3.0.1</findbugs.maven.plugin.ver>
-		<maven.javadoc.plugin.ver>2.10.3</maven.javadoc.plugin.ver>
-		<jdepend.maven.plugin.ver>2.0</jdepend.maven.plugin.ver>
-		<taglist.maven.plugin.ver>2.4</taglist.maven.plugin.ver>
+
+        <!-- Reporting plug-ins.  See http://maven.apache.org/plugins/ with an R in the type column
+             for report options and versions. -->
+        <cobertura.maven.plugin.ver>2.7</cobertura.maven.plugin.ver>
+        <findbugs.maven.plugin.ver>3.0.3</findbugs.maven.plugin.ver>
+        <jdepend.maven.plugin.ver>2.0</jdepend.maven.plugin.ver>
+        <maven.changelog.plugin.ver>2.3</maven.changelog.plugin.ver>
+        <maven.javadoc.plugin.ver>2.10.3</maven.javadoc.plugin.ver>
+        <maven.jxr.plugin.ver>2.5</maven.jxr.plugin.ver>
+        <maven.pmd.plugin.ver>3.5</maven.pmd.plugin.ver>
+        <maven.project.info.reports.plugin.ver>2.8.1</maven.project.info.reports.plugin.ver>
+        <maven.surefire.report.plugin.ver>2.19</maven.surefire.report.plugin.ver>
+        <taglist.maven.plugin.ver>2.4</taglist.maven.plugin.ver>
+
     </properties>
     
     <build>
@@ -209,6 +213,70 @@
         </plugins>
     </build>
 
+    <reporting>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jxr-plugin</artifactId>
+                <version>${maven.jxr.plugin.ver}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-project-info-reports-plugin</artifactId>
+                <version>${maven.project.info.reports.plugin.ver}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-report-plugin</artifactId>
+                <version>${maven.surefire.report.plugin.ver}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>cobertura-maven-plugin</artifactId>
+                <version>${cobertura.maven.plugin.ver}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-pmd-plugin</artifactId>
+                <version>${maven.pmd.plugin.ver}</version>
+                <configuration>
+                    <linkXref>true</linkXref>
+                    <sourceEncoding>utf-8</sourceEncoding>
+                    <minimumTokens>100</minimumTokens>
+                    <targetJdk>${project.build.sourceVersion}</targetJdk>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-changelog-plugin</artifactId>
+                <version>${maven.changelog.plugin.ver}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>taglist-maven-plugin</artifactId>
+                <version>${taglist.maven.plugin.ver}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>findbugs-maven-plugin</artifactId>
+                <version>${findbugs.maven.plugin.ver}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>${maven.javadoc.plugin.ver}</version>
+                <configuration>
+                    <source>${project.build.sourceVersion}</source>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>jdepend-maven-plugin</artifactId>
+                <version>${jdepend.maven.plugin.ver}</version>
+            </plugin>
+        </plugins>
+    </reporting>
+
     <profiles>
         <profile>
             <id>jasig-release</id>
@@ -282,69 +350,6 @@
                                     <version>${wagon.webdav.jackrabbit.ver}</version>
                                 </dependency>
                             </dependencies>
-                            <configuration>
-                                <reportPlugins>
-                                    <plugin>
-                                    	<groupId>org.apache.maven.plugins</groupId>
-                                        <artifactId>maven-jxr-plugin</artifactId>
-                                        <version>${maven.jxr.plugin}</version>
-                                    </plugin>
-                                    <plugin>
-                                    	<groupId>org.apache.maven.plugins</groupId>
-                                        <artifactId>maven-project-info-reports-plugin</artifactId>
-                                        <version>${maven.project.info.reports.plugin.ver}</version>
-                                    </plugin>
-                                    <plugin>
-                                    	<groupId>org.apache.maven.plugins</groupId>
-                                        <artifactId>maven-surefire-report-plugin</artifactId>
-                                        <version>${maven.surefire.report.plugin.ver}</version>
-                                    </plugin>
-                                    <plugin>
-                                        <groupId>org.codehaus.mojo</groupId>
-                                        <artifactId>cobertura-maven-plugin</artifactId>
-                                        <version>${cobertura.maven.plugin.ver}</version>
-                                    </plugin>
-                                    <plugin>
-                                    	<groupId>org.apache.maven.plugins</groupId>
-                                        <artifactId>maven-pmd-plugin</artifactId>
-                                        <version>${maven.pmd.plugin.ver}</version>
-                                        <configuration>
-                                            <linkXref>true</linkXref>
-                                            <sourceEncoding>utf-8</sourceEncoding>
-                                            <minimumTokens>100</minimumTokens>
-                                            <targetJdk>${project.build.sourceVersion}</targetJdk>
-                                        </configuration>
-                                    </plugin>
-                                    <plugin>
-                                    	<groupId>org.apache.maven.plugins</groupId>
-                                        <artifactId>maven-changelog-plugin</artifactId>
-                                        <version>${maven.changelog.plugin.ver}</version>
-                                    </plugin>
-                                    <plugin>
-                                        <groupId>org.codehaus.mojo</groupId>
-                                        <artifactId>taglist-maven-plugin</artifactId>
-                                        <version>${taglist.maven.plugin.ver}</version>
-                                    </plugin>
-                                    <plugin>
-                                        <groupId>org.codehaus.mojo</groupId>
-                                        <artifactId>findbugs-maven-plugin</artifactId>
-                                        <version>${findbugs.maven.plugin.ver}</version>
-                                    </plugin>
-                                    <plugin>
-                                    	<groupId>org.apache.maven.plugins</groupId>
-                                        <artifactId>maven-javadoc-plugin</artifactId>
-                                        <version>${maven.javadoc.plugin.ver}</version>
-                                        <configuration>
-                                            <source>${project.build.sourceVersion}</source>
-                                        </configuration>
-                                    </plugin>
-                                    <plugin>
-                                        <groupId>org.codehaus.mojo</groupId>
-                                        <artifactId>jdepend-maven-plugin</artifactId>
-                                        <version>${jdepend.maven.plugin.ver}</version>
-                                    </plugin>
-                                </reportPlugins>
-                            </configuration>
                         </plugin>
                     </plugins>
                 </pluginManagement>


### PR DESCRIPTION
- Fix the reporting plug-ins which no longer can reside in the <reportPlugins> element per https://maven.apache.org/plugins/maven-site-plugin/maven-3.html#Configuration_formats.
- Updated reports to latest versions
- Also updated the license templates from Jasig to Apereo to match https://source.jasig.org/licenses/ and added missing license for opensymphony
- Updated README with important info
